### PR TITLE
Add support for Simple Email Service

### DIFF
--- a/lib/aws.js
+++ b/lib/aws.js
@@ -5,6 +5,12 @@ var events = require("events")
 var xml2js = require("xml2js")
 
 
+// Returns the hmac digest using the SHA256 algorithm.
+function hmacSha256(key, toSign) {
+  var hash = crypto.createHmac("sha256", key);
+  return hash.update(toSign).digest("base64");
+}
+
 // Creates an EC2 API client
 exports.createEC2Client = function (accessKeyId, secretAccessKey, options) {
   options = options || {};
@@ -66,6 +72,19 @@ exports.createSimpleDBClient = function (accessKeyId, secretAccessKey, options) 
   });
   return client;
 }
+
+// Creates a Simple Email Service API client
+exports.createSESClient = function (accessKeyId, secretAccessKey, options) {
+  options = options || {};
+  return sesClient({
+    host: options.host || "email.us-east-1.amazonaws.com",
+    path: options.path || "/",
+    accessKeyId: accessKeyId,
+    secretAccessKey: secretAccessKey,
+    secure: true,
+    version: options.version
+  });
+};
 
 // Amazon EC2 API handler which is wrapped around the genericAWSClient
 var ec2Client = function(obj) {
@@ -134,31 +153,61 @@ var simpledbClient = function(obj) {
   return obj;
 }
 
+// Amazon SES API handler which is wrapped around the genericAWSClient
+var sesClient = function (obj) {
+  var aws = genericAWSClient({
+    host: obj.host,
+    path: obj.path,
+    accessKeyId: obj.accessKeyId,
+    secretAccessKey: obj.secretAccessKey,
+    secure: obj.secure,
+    signHeader: true
+  });
+
+  obj.call = function(action, query, callback) {
+    query["Action"] = action
+    return aws.call(action, query, callback);
+  }
+
+  return obj;
+};
+
 // a generic AWS API Client which handles the general parts
 var genericAWSClient = function(obj) {
   var creds = crypto.createCredentials({});
   if (null == obj.secure) obj.secure = true;
-  
+
   obj.connection = http.createClient(obj.secure ? 443 : 80, obj.host, obj.secure, creds);
   obj.call = function (action, query, callback) {
     if (obj.secretAccessKey == null || obj.accessKeyId == null) {
       throw("secretAccessKey and accessKeyId must be set")
     }
 
-    var now = new Date()
-    var ts = now.toISOString()
+    var now = new Date();
+    if (!obj.signHeader) {
+      // add the standard parameters required by all AWS APIs
+      query["Timestamp"] = now.toISOString();
+      query["AWSAccessKeyId"] = obj.accessKeyId;
+      query["Signature"] = obj.sign(query)
+    }
 
-    // add the standard parameters required by all AWS APIs
-    query["Timestamp"] = ts;
-    query["AWSAccessKeyId"] = obj.accessKeyId;
-    query["Signature"] = obj.sign(query)
-
-    var body = qs.stringify(query)
-    var req = obj.connection.request("POST", obj.path, {
+    var body = qs.stringify(query);
+    var headers = {
       "Host": obj.host,
       "Content-Type": "application/x-www-form-urlencoded",
       "Content-Length": body.length
-    })
+    };
+
+    if (obj.signHeader) {
+      headers["date"] = now.toUTCString();
+      headers["x-amzn-authorization"] =
+        "AWS3-HTTPS " +
+        "AWSAccessKeyId=" + obj.accessKeyId + ", " +
+        "Algorithm=HmacSHA256, " + 
+        "Signature=" + hmacSha256(obj.secretAccessKey, now.toUTCString());
+    }
+
+    var req = obj.connection.request("POST", obj.path, headers)
 
     //the listener that retrieves the response
     req.addListener('response', function (res) {
@@ -184,7 +233,6 @@ var genericAWSClient = function(obj) {
     Calculate HMAC signature of the query
    */
   obj.sign = function (query) {
-    var hash = crypto.createHmac("sha256", obj.secretAccessKey)
     var keys = []
     var sorted = {}
 
@@ -202,8 +250,7 @@ var genericAWSClient = function(obj) {
     // Amazon signature algorithm seems to require this
     stringToSign = stringToSign.replace(/'/g,"%27");
     stringToSign = stringToSign.replace(/\*/g,"%2A");
-    
-    return hash.update(stringToSign).digest("base64")
+    return hmacSha256(obj.secretAccessKey, stringToSign);
   }
 
   return obj;


### PR DESCRIPTION
This adds support for SES - I had to rework a little more than I'd have liked to because Amazon decided to change up how request signing is done for SES.

Secure and non-secure signing for SES also use different algorithms so I'm ignoring the `secure` option on SES for now until non-secure gets implemented.
