### PR TITLE
Add support for Simple Email Service

### DIFF
--- a/lib/aws.js
+++ b/lib/aws.js
@@ -10,6 +10,13 @@ var prodAdv = require("./prodAdv");
 var simpledb = require("./simpledb");
 var sqs = require("./sqs");
 var sns = require("./sns");
+var ses = require("./ses");
+
+// Returns the hmac digest using the SHA256 algorithm.
+function hmacSha256(key, toSign) {
+  var hash = crypto.createHmac("sha256", key);
+  return hash.update(toSign).digest("base64");
+}
 
 // a generic AWS API Client which handles the general parts
 var genericAWSClient = function(obj) {
@@ -22,20 +29,32 @@ var genericAWSClient = function(obj) {
       throw("secretAccessKey and accessKeyId must be set")
     }
 
-    var now = new Date()
-    var ts = now.toISOString()
+    var now = new Date();
 
-    // add the standard parameters required by all AWS APIs
-    query["Timestamp"] = ts;
-    query["AWSAccessKeyId"] = obj.accessKeyId;
-    query["Signature"] = obj.sign(query)
+    if (!obj.signHeader) {
+      // Add the standard parameters required by all AWS APIs
+      query["Timestamp"] = now.toISOString();
+      query["AWSAccessKeyId"] = obj.accessKeyId;
+      query["Signature"] = obj.sign(query);
+    }
 
-    var body = qs.stringify(query)
-    var req = obj.connection.request("POST", obj.path, {
+    var body = qs.stringify(query);
+    var headers = {
       "Host": obj.host,
       "Content-Type": "application/x-www-form-urlencoded",
       "Content-Length": body.length
-    })
+    };
+
+    if (obj.signHeader) {
+      headers["Date"] = now.toUTCString();
+      headers["X-Amzn-Authorization"] =
+        "AWS3-HTTPS " +
+        "AWSAccessKeyId=" + obj.accessKeyId + ", " +
+        "Algorithm=HmacSHA256, " +
+        "Signature=" + hmacSha256(obj.secretAccessKey, now.toUTCString());
+    }
+
+    var req = obj.connection.request("POST", obj.path, headers);
 
     //the listener that retrieves the response
     req.addListener('response', function (res) {
@@ -61,7 +80,6 @@ var genericAWSClient = function(obj) {
     Calculate HMAC signature of the query
    */
   obj.sign = function (query) {
-    var hash = crypto.createHmac("sha256", obj.secretAccessKey)
     var keys = []
     var sorted = {}
 
@@ -79,8 +97,8 @@ var genericAWSClient = function(obj) {
     // Amazon signature algorithm seems to require this
     stringToSign = stringToSign.replace(/'/g,"%27");
     stringToSign = stringToSign.replace(/\*/g,"%2A");
-    
-    return hash.update(stringToSign).digest("base64")
+
+    return hmacSha256(obj.secretAccessKey, stringToSign);
   }
 
   return obj;
@@ -90,3 +108,4 @@ exports.createProdAdvClient = prodAdv.init(genericAWSClient);
 exports.createSimpleDBClient = simpledb.init(genericAWSClient);
 exports.createSQSClient = sqs.init(genericAWSClient);
 exports.createSNSClient = sns.init(genericAWSClient);
+exports.createSESClient = ses.init(genericAWSClient);

--- a/lib/ses.js
+++ b/lib/ses.js
@@ -1,0 +1,26 @@
+exports.init = function (genericAWSClient) {
+  var createSESClient = function (accessKeyId, secretAccessKey, options) {
+    options = options || {};
+    options.host = options.host || "email.us-east-1.amazonaws.com";
+    options.path = options.path || "/";
+
+    var obj = {
+      host: options.host,
+      path: options.path,
+      accessKeyId: accessKeyId,
+      secretAccessKey: secretAccessKey,
+      secure: true,
+      signHeader: true
+    };
+
+    obj.call = function(action, query, callback) {
+      var aws = genericAWSClient(obj);
+      query["Action"] = action;
+      return aws.call(action, query, callback);
+    }
+
+    return obj;
+  };
+
+  return createSESClient;
+};


### PR DESCRIPTION
New pull request after the major refactoring - original info below:

This adds support for SES - I had to rework a little more than I'd have liked to because Amazon decided to change up how request signing is done for SES.

Secure and non-secure signing for SES also use different algorithms so I'm ignoring the secure option on SES for now until non-secure gets implemented.
