### PR TITLE
add utf-8 and replace parens with url encoded versions

### DIFF
--- a/lib/aws.js
+++ b/lib/aws.js
@@ -42,7 +42,7 @@ var genericAWSClient = function(obj) {
     var body = qs.stringify(query);
     var headers = {
       "Host": obj.host,
-      "Content-Type": "application/x-www-form-urlencoded",
+      "Content-Type": "application/x-www-form-urlencoded; charset=utf-8",
       "Content-Length": body.length
     };
 
@@ -99,6 +99,8 @@ var genericAWSClient = function(obj) {
     // Amazon signature algorithm seems to require this
     stringToSign = stringToSign.replace(/'/g,"%27");
     stringToSign = stringToSign.replace(/\*/g,"%2A");
+    stringToSign = stringToSign.replace(/\(/g,"%28");
+    stringToSign = stringToSign.replace(/\)/g,"%29");
 
     return hmacSha256(obj.secretAccessKey, stringToSign);
   }


### PR DESCRIPTION
This was needed for me to get simpledb requests containing parentheses to be accepted by the API.  Without these changes I would get 'SignatureDoesNotMatch' errors from the simpledb API.  I wonder how many other characters need to be url encoded...

Anyway, these changes fix [this issue](https://github.com/rjrodger/simpledb/issues#issue/4) in [rjrodjer's simpledb library](https://github.com/rjrodger/simpledb) that depends on the aws-lib library.
