### PR TITLE
Sign method failed if Array.prototype was modified.

### DIFF
--- a/lib/aws.js
+++ b/lib/aws.js
@@ -91,8 +91,10 @@ var genericAWSClient = function(obj) {
     keys = keys.sort()
 
     for(n in keys) {
-      var key = keys[n]
-      sorted[key] = query[key]
+      if(keys.hasOwnProperty(n)) {
+        var key = keys[n]
+        sorted[key] = query[key]
+      }
     }
     var stringToSign = ["POST", obj.host, obj.path, qs.stringify(sorted)].join("\n");
 


### PR DESCRIPTION
Added a hasOwnProperty guard to the for..in in the sign method.
