### PR TITLE
Fix dependency issue with xml2js since the one on npm is no longer functional

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "Ross Duggan <ross@boards.ie> (http://rossduggan.ie/)"
   ],
   "dependencies": {
-      "xml2js": "0.1.x",
+      "xml2js": "https://github.com/Leonidas-from-XIV/node-xml2js/tarball/master",
       "sax": "0.1.x"
   },
   "main": "lib/aws",


### PR DESCRIPTION
Update dependencies to include maintained and updated xml2js repository since the version on npm does not have a correct package.json
