### PR TITLE
Added ! to list of escaped characters in sign()

### DIFF
--- a/lib/aws.js
+++ b/lib/aws.js
@@ -97,6 +97,7 @@ var genericAWSClient = function(obj) {
     var stringToSign = ["POST", obj.host, obj.path, qs.stringify(sorted)].join("\n");
 
     // Amazon signature algorithm seems to require this
+    stringToSign = stringToSign.replace(/!/g,"%21");
     stringToSign = stringToSign.replace(/'/g,"%27");
     stringToSign = stringToSign.replace(/\*/g,"%2A");
     stringToSign = stringToSign.replace(/\(/g,"%28");


### PR DESCRIPTION
When signing messages containing '!', you get an error. This patch is needed for bangs to work properly.

http://labs.apache.org/webarch/uri/rfc/rfc3986.html#reserved
