### PR TITLE
Changes 'end' to 'close' on https request response

### DIFF
--- a/lib/aws.js
+++ b/lib/aws.js
@@ -68,13 +68,16 @@ var genericAWSClient = function(obj) {
       res.addListener('data', function (chunk) {
         data += chunk.toString()
       })
-      res.addListener('close', function() {
+      var cb = function() {
         var parser = new xml2js.Parser();
         parser.addListener('end', function(result) {
           callback(result);
         });
         parser.parseString(data);
-      })
+      };
+      
+      res.addListener('end', cb)
+      res.addListener('close', cb)
     });
     req.write(body)
     req.end()


### PR DESCRIPTION
See: https://github.com/joyent/node/issues/728#issuecomment-1730080
The end event apparently isn't reliable as of node 4.8...
