### PR TITLE
Handle empty responses from AWS.

### DIFF
--- a/lib/aws.js
+++ b/lib/aws.js
@@ -73,15 +73,20 @@ var genericAWSClient = function(obj) {
         data += chunk.toString()
       })
       res.addListener('end', function() {
-        var parser = new xml2js.Parser();
-        parser.addListener('end', function(result) {
-          if (typeof result != "undefined" && typeof result.Errors != "undefined"){
-            callback(result.Errors.Error.Message, result)
-          } else {
-            callback(null, result)
-          }
-        });
-        parser.parseString(data);
+        if (data === '' && (res.statusCode >= 400 || res.statusCode < 600)) {
+          callback(res.statusCode, null);
+        }
+        else {
+          var parser = new xml2js.Parser();
+          parser.addListener('end', function(result) {
+            if (typeof result != "undefined" && typeof result.Errors != "undefined"){
+              callback(result.Errors.Error.Message, result)
+            } else {
+              callback(null, result)
+            }
+          });
+          parser.parseString(data);
+        }
       })
     });
     req.write(body)


### PR DESCRIPTION
I've noticed scenarios where calls to AWS contain empty response bodies with error status codes. This is just a suggestion on how that could be handled.
