### PR TITLE
Pass Error object back rather than string.

### DIFF
--- a/lib/aws.js
+++ b/lib/aws.js
@@ -76,7 +76,7 @@ var genericAWSClient = function(obj) {
         var parser = new xml2js.Parser();
         parser.addListener('end', function(result) {
           if (typeof result != "undefined" && typeof result.Errors != "undefined"){
-            callback(result.Errors.Error.Message, result)
+            callback(new Error(result.Errors.Error.Message), result)
           } else {
             callback(null, result)
           }


### PR DESCRIPTION
Following the convention established by node.js core modules, this pull wraps an error string returned from AWS in an `Error()` object. This has a few advantages including that `err` can simply be thrown inside callbacks.

```
ec2.call('DescribeVolumes', params, function(err, result) { 
    if (err) throw err;
});
```
