### PR TITLE
fix when response is empty

### DIFF
--- a/lib/aws.js
+++ b/lib/aws.js
@@ -79,7 +79,7 @@ var genericAWSClient = function(obj) {
         else {
           var parser = new xml2js.Parser();
           parser.addListener('end', function(result) {
-            if (typeof result != "undefined" && typeof result.Errors != "undefined"){
+            if (result && typeof result.Errors != "undefined"){
               callback(new Error(result.Errors.Error.Message), result)
             } else {
               callback(null, result)


### PR DESCRIPTION
i was getting an error when the response from amazon came back empty.  in that case, the parser returns result as null rather than undefined.  checking for result.Errors then crashes node.

my fix was to check if data === '' before running the parser.
