### PR TITLE
Creating queues with non-default attributes doesn't work with the default API version.

### DIFF
--- a/lib/sqs.js
+++ b/lib/sqs.js
@@ -12,7 +12,7 @@ exports.init = function(genericAWSClient) {
     })
     var callFn = function(action, query, callback) {
       query["Action"] = action
-      query["Version"] = options.version || '2009-02-01'
+      query["Version"] = options.version || '2011-10-01'
       query["SignatureMethod"] = "HmacSHA256"
       query["SignatureVersion"] = "2"
       return aws.call(action, query, callback);

--- a/test/sqs.js
+++ b/test/sqs.js
@@ -8,10 +8,45 @@ sqs = aws.createSQSClient(credentials.accessKeyId, credentials.secretAccessKey);
 describe('sqs', function() {
   describe('ListQueues', function() {
     it('should return all queues', function(done) {
-      sqs.call ( "ListQueues", {}, function (err, res) { 
+      sqs.call('ListQueues', {}, function (err, res) {
         assert.ok(res.ListQueuesResult);
-        done(err) 
+        done(err);
       });
-    })
-  })
-})
+    });
+  });
+
+  describe('CreateQueue', function() {
+    var queueName;
+    var queueSqs;
+
+    beforeEach(function(done) {
+      require('crypto').randomBytes(16, function(err, buf) {
+        queueName = 'test-' + buf.toString('hex');
+        done(err);
+      });
+      queueSqs = null;
+    });
+
+    afterEach(function(done) {
+      queueSqs.call('DeleteQueue', {}, done);
+    });
+
+    it('should create the queue with the specified attributes', function(done) {
+      var params = {
+        'QueueName': queueName,
+        'Attribute.1.Name': 'VisibilityTimeout',
+        'Attribute.1.Value': 1234
+      };
+
+      sqs.call('CreateQueue', params, function(err, res) {
+        var queuePath = require('url').parse(res.CreateQueueResult.QueueUrl).path;
+        queueSqs = aws.createSQSClient(credentials.accessKeyId, credentials.secretAccessKey, { path: queuePath });
+
+        queueSqs.call('GetQueueAttributes', { 'AttributeName.1': 'VisibilityTimeout' }, function(err, res) {
+          assert.equal(res.GetQueueAttributesResult.Attribute.Value, '1234');
+          done(err);
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Although undocumented as such, when using the older version of the SQS API (2009-02-01), CreateQueue uses the _default_ queue attributes (Policy, VisibilityTimeout) even if you specify them.

This commit just bumps the default version and adds a test around this behavior.
