### PR TITLE
Add support for EC2 metadata API, including automatic lookup of IAM acce...

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,24 @@ which would instantiate the ec2 client, but using the 2010-08-31 API version.  S
 
 For more examples have a look at [/examples](https://github.com/livelycode/aws-lib/tree/master/examples) and [/test](https://github.com/livelycode/aws-lib/tree/master/test).
 
+## Credentials, metadata API, and IAM Roles
+
+If you use aws-lib on EC2s it is necessary to distribute your AWS API access key and secret id to each EC2 in order to authenticate requests.  [IAM Roles](http://docs.amazonwebservices.com/AWSEC2/latest/UserGuide/UsingIAM.html#UsingIAMrolesWithAmazonEC2Instances) removes the need to manually distribute your AWS API access key and secret id to EC2s.  Create an IAM role(s) and assign to your EC2s (CloudFormation supports IAM Roles). An access key, secret id, and token will then be provided on the EC2 metadata API.  You can then use aws-lib without passing in any credentials to API clients.  For example:
+
+    var aws = require("aws-lib");
+    ec2 = aws.createEC2Client(); // Notice no access key nor secret id passed in to client
+    ec2.call("DescribeInstances", {}, function(err, result) {
+      console.log(JSON.stringify(result));
+    });
+
+If no access key or secret id are passed in to the client, aws-lib will attempt to look up the credentials from the EC2 metadata API.  The metadata API can also be used like other aws-lib API clients, such as:
+
+    var aws = require("aws-lib");
+    var md = aws.createMetaDataClient();
+    md.call({endpoint: 'instance-id'}, function(err, res) {
+      console.log(res); // outputs this EC2's instance-id.
+    });
+
 ## Tests
 In order to run the tests you need to copy "test/credentials_template.js" to "test/credentials.js" and add your access key and secret.  
 credentials.js is part of .gitignore so you don't have to worry about accidentially commiting your secret.

--- a/lib/aws.js
+++ b/lib/aws.js
@@ -19,12 +19,43 @@ var cw = require("./cw");
 var as = require("./as");
 var cfn = require("./cfn");
 var emr = require("./emr");
+var metadata = require("./metadata.js");
 
 // Returns the hmac digest using the SHA256 algorithm.
 function hmacSha256(key, toSign) {
   var hash = crypto.createHmac("sha256", key);
   return hash.update(toSign).digest("base64");
 }
+
+// Try to get access id and secret key from ec2 metadata API
+function checkCredentials(obj, cb) {
+  var lapse = obj.expires == null ? 0 : +new Date() - Date.parse(obj.expires);
+  if (obj.secretAccessKey == null || obj.accessKeyId == null || lapse > 0) {
+    var md = metadata.init();
+    md().call({endpoint: 'iam/security-credentials/'}, function(err, res) {
+      if (err) cb(err);
+      if (typeof res === 'undefined') cb(new Error('metadata API response undefined'));
+      md().call({endpoint: 'iam/security-credentials/' + res.split('\n')[0]},
+       function(err, res) {
+        try {
+          res = JSON.parse(res);
+        } catch(e) {
+          cb(e);
+        }
+        if (res.SecretAccessKey === null)
+          cb(new Error("secretAccessKey and accessKeyId not provided and could not be determined."));
+        obj.secretAccessKey = res.SecretAccessKey;
+        obj.accessKeyId = res.AccessKeyId;
+        obj.token = res.Token;
+        obj.expires = res.Expiration;
+        cb(null, obj);
+      });
+    });
+  } else {
+    cb(null, obj);
+  }
+}
+
 // a generic AWS API Client which handles the general parts
 var genericAWSClient = function(obj) {
   var creds = crypto.createCredentials({});
@@ -33,62 +64,62 @@ var genericAWSClient = function(obj) {
 
   obj.connection = obj.secure ? https : http;
   obj.call = function (action, query, callback) {
-    if (obj.secretAccessKey == null || obj.accessKeyId == null) {
-      throw("secretAccessKey and accessKeyId must be set")
-    }
+    checkCredentials(obj, function(err, obj) {
+      if (err) throw err;
+      var now = new Date();
+      if (!obj.signHeader) {
+        // Add the standard parameters required by all AWS APIs
+        if (obj.token !== undefined) query["SecurityToken"] = obj.token;
+        query["Timestamp"] = now.toISOString();
+        query["AWSAccessKeyId"] = obj.accessKeyId;
+        query["Signature"] = obj.sign(query);
+      }
 
-    var now = new Date();
+      var body = qs.stringify(query);
+      var headers = {
+        "Host": obj.host,
+        "Content-Type": "application/x-www-form-urlencoded; charset=utf-8",
+        "Content-Length": body.length
+      };
 
-    if (!obj.signHeader) {
-      // Add the standard parameters required by all AWS APIs
-      query["Timestamp"] = now.toISOString();
-      query["AWSAccessKeyId"] = obj.accessKeyId;
-      query["Signature"] = obj.sign(query);
-    }
+      if (obj.signHeader) {
+        headers["Date"] = now.toUTCString();
+        if (obj.token !== undefined) headers["x-amz-security-token"] = obj.token;
+        headers["x-amzn-authorization"] =
+        "AWS3-HTTPS " +
+        "AWSAccessKeyId=" + obj.accessKeyId + ", " +
+        "Algorithm=HmacSHA256, " +
+        "Signature=" + hmacSha256(obj.secretAccessKey, now.toUTCString());
+      }
 
-    var body = qs.stringify(query);
-    var headers = {
-      "Host": obj.host,
-      "Content-Type": "application/x-www-form-urlencoded; charset=utf-8",
-      "Content-Length": body.length
-    };
-
-    if (obj.signHeader) {
-      headers["Date"] = now.toUTCString();
-      headers["x-amzn-authorization"] =
-      "AWS3-HTTPS " +
-      "AWSAccessKeyId=" + obj.accessKeyId + ", " +
-      "Algorithm=HmacSHA256, " +
-      "Signature=" + hmacSha256(obj.secretAccessKey, now.toUTCString());
-    }
-
-    var options = {
-      host: obj.host,
-      path: obj.path,
-      agent: obj.agent,
-      method: 'POST',
-      headers: headers
-    };
-    var req = obj.connection.request(options, function (res) {
-      var data = '';
-      //the listener that handles the response chunks
-      res.addListener('data', function (chunk) {
-        data += chunk.toString()
-      })
-      res.addListener('end', function() {
-        var parser = new xml2js.Parser();
-        parser.addListener('end', function(result) {
-          if (typeof result != "undefined" && typeof result.Errors != "undefined"){
-            callback(new Error(result.Errors.Error.Message), result)
-          } else {
-            callback(null, result)
-          }
-        });
-        parser.parseString(data);
-      })
+      var options = {
+        host: obj.host,
+        path: obj.path,
+        agent: obj.agent,
+        method: 'POST',
+        headers: headers
+      };
+      var req = obj.connection.request(options, function (res) {
+        var data = '';
+        //the listener that handles the response chunks
+        res.addListener('data', function (chunk) {
+          data += chunk.toString()
+        })
+        res.addListener('end', function() {
+          var parser = new xml2js.Parser();
+          parser.addListener('end', function(result) {
+            if (typeof result != "undefined" && typeof result.Errors != "undefined"){
+              callback(new Error(result.Errors.Error.Message), result)
+            } else {
+              callback(null, result)
+            }
+          });
+          parser.parseString(data);
+        })
+      });
+      req.write(body)
+      req.end()  
     });
-    req.write(body)
-    req.end()
   }
   /*
    Calculate HMAC signature of the query
@@ -133,3 +164,4 @@ exports.createCWClient = cw.init(genericAWSClient);
 exports.createASClient = as.init(genericAWSClient);
 exports.createCFNClient = cfn.init(genericAWSClient);
 exports.createEMRClient = emr.init(genericAWSClient);
+exports.createMetaDataClient = metadata.init();

--- a/lib/metadata.js
+++ b/lib/metadata.js
@@ -1,0 +1,31 @@
+var http = require('http');
+
+exports.init = function() {
+  return function () {
+    return {
+      call: function(options, callback) {
+        var version = options.version || 'latest';
+        var endpoint = options.endpoint || '';
+        var url = 'http://169.254.169.254/' + version + '/meta-data/' + endpoint;
+
+        http.get(url, function(res) {
+          var string = '';
+          res.setEncoding('utf8');
+          res.on('data', function(chunk) {
+            string += chunk;
+          });
+          res.on('end', function() {
+            if (res.statusCode == 200) {
+              return callback(null, string);
+            } else {
+              return callback(new Error('HTTP ' + res.statusCode +
+                ' when fetching credentials from EC2 API'));
+            }
+          });
+        })
+        .once('error', callback)
+        .setTimeout(1000, callback);
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -18,10 +18,11 @@
       "sax": "0.1.x"
   },
   "devDependencies": {
-    "mocha": "*"
+    "mocha": "*",
+    "nock": "0.14.x"
   },
   "scripts": {
-    "test": "./node_modules/.bin/mocha"
+    "test": "./node_modules/.bin/mocha -t 60000"
   },
   "main": "lib/aws",
   "directories": {

--- a/test/metadata.js
+++ b/test/metadata.js
@@ -1,0 +1,107 @@
+var assert = require('assert');
+var aws = require('../lib/aws');
+var nock = require('nock');
+var credentials = require('./credentials');
+var ec2auth = aws.createEC2Client(credentials.accessKeyId, credentials.secretAccessKey);
+var ec2unauth = aws.createEC2Client();
+var md = aws.createMetaDataClient();
+var expires = new Date(+new Date + 10000).toISOString();
+var fake = {
+  "Code" : "Success",
+  "LastUpdated" : "2012-12-12T21:04:14Z",
+  "Type" : "AWS-HMAC",
+  "AccessKeyId" : "XXX",
+  "SecretAccessKey" : "XXX",
+  "Token" : "XXX",
+  "Expiration" : expires
+};
+
+var valid = {
+  "Code" : "Success",
+  "LastUpdated" : "2012-12-12T21:04:14Z",
+  "Type" : "AWS-HMAC",
+  "AccessKeyId" : credentials.accessKeyId,
+  "SecretAccessKey" : credentials.secretAccessKey,
+  "Token" : undefined,
+  "Expiration" : expires
+};
+
+var api = nock('http://169.254.169.254')
+  .get('/latest/meta-data/instance-id')
+  .reply(200, 'i-abcdef12')
+  .get('/latest/meta-data/iam/security-credentials/')
+  .reply(200, 'role1')
+  .get('/latest/meta-data/iam/security-credentials/')
+  .reply(200, 'role1')
+  .get('/latest/meta-data/iam/security-credentials/role1')
+  .reply(200, fake)
+  .get('/latest/meta-data/iam/security-credentials/')
+  .reply(200, 'role1')
+  .get('/latest/meta-data/iam/security-credentials/role1')
+  .reply(200, fake)
+  .get('/latest/meta-data/iam/security-credentials/')
+  .reply(200, 'role1')
+  .get('/latest/meta-data/iam/security-credentials/role1')
+  .reply(200, valid);
+
+describe('metadata api', function() {
+  it('should return an instance-id', function(done) {
+    md.call({endpoint: 'instance-id'}, function(err, res) {
+      assert.equal(res, 'i-abcdef12');
+      done(err)
+    })
+  })
+  it('should return a role', function(done) {
+    md.call({endpoint: 'iam/security-credentials/'}, function(err, res) {
+      assert.equal(res, 'role1');
+      done(err)
+    })
+  })
+  it('should return a parsable JSON object', function(done) {
+    md.call({endpoint: 'iam/security-credentials/'}, function(err, res) {
+      md.call({endpoint: 'iam/security-credentials/' + res}, function(err, res) {
+        res = JSON.parse(res);
+        assert.equal(res.AccessKeyId, 'XXX');
+        done(err)
+      });
+    })
+  })
+  // Should use real key/secret
+  it('should use provided credentials and return reservation set', function(done) {
+    ec2auth.call("DescribeInstances", {}, function(err, res) {
+      assert.ok(res.reservationSet);
+      done(err)
+    })
+  })
+  // Should look up fake key/secret, and not be able to authenticate
+  it('should call metadata api and throw authentication exception', function(done) {
+    ec2unauth.call("DescribeInstances", {}, function(err, res) {
+      assert.throws(
+        function() {
+          throw new Error(err);
+        },
+        /AWS was not able/
+      );
+      done();
+    })
+  })
+  // Force credentials to expire, which should call metadata API to get new
+  // credentials. New credentials will be valid and therefore should result
+  // in valid result from ec2 api. Note, causes delay and therefore may
+  // cause test timeout.
+  it('should re-call metadata api and return ec2 result', function(done) {
+    if (Date.parse(expires) > +new Date) {
+      setTimeout(function() {
+        ec2unauth.call("DescribeInstances", {}, function(err, res) {
+          assert.ok(res.reservationSet);
+          done(err);
+        })
+      }, Date.parse(expires) - (+new Date - 2000))
+    } else {
+        ec2unauth.call("DescribeInstances", {}, function(err, res) {
+          assert.ok(res.reservationSet);
+          done(err);
+        })
+    }
+  })
+});


### PR DESCRIPTION
...ss key and secret ID when IAM roles are used. This commit also increases the timeout of mocha tests in order to allow for testing IAM role credential cache expiry. Increased test timeout also increases liklihood of tests completing when run from a slower internet connection.

Pull request includes tests and documentation about the why/how of the metadata API and IAM Roles.  I added a nock dependency which makes writing tests around the metadata API possible.
