### PR TITLE
Return the request object in call

### DIFF
--- a/lib/aws.js
+++ b/lib/aws.js
@@ -131,6 +131,8 @@ var genericAWSClient = function(obj) {
       req.write(body)
       req.addListener('error', callback)
       req.end()
+
+      return req;
     });
   }
   /*


### PR DESCRIPTION
I had a need to setup a timeout on the request for some hanging SQS calls.

You can now setup code like this:

```
  req = sqs.call "GetQueueAttributes", options, (err, result) ->
    ...

  req.on "error", ->
    # handle error

  # setup the timeout  
  req.on "socket", (s) ->
    s.setTimeout 100
    s.on "timeout", -> do req.abort
```

Or, if you would like, I can change it up to include a timeout property in the options object. (If returning the request scares you :smile:)
