### PR TITLE
Fixes problem where filters are not working for EC2 requests.

### DIFF
--- a/lib/ec2.js
+++ b/lib/ec2.js
@@ -10,11 +10,17 @@ exports.init = function(genericAWSClient) {
       secretAccessKey: secretAccessKey,
       secure: options.secure
     });
-    var callFn = function(action, query, callback) {
+    var callFn = function(action, opts, callback) {
+	  var query = {};
       query["Action"] = action
-      query["Version"] = options.version || "2009-11-30"
+      query["Version"] = options.version || "2012-12-01"
       query["SignatureMethod"] = "HmacSHA256"
       query["SignatureVersion"] = "2"
+      //add options to the end of the query
+	  for(var key in opts){
+		   query[key] = opts[key];
+	   }
+
       return aws.call(action, query, callback);
     }
     return {call: callFn};

--- a/test/ec2.js
+++ b/test/ec2.js
@@ -14,4 +14,16 @@ describe('ec2', function() {
       })
     })
   })
+  describe('DescribeInstances', function() {
+	it('should return the reservationSet', function(done) {
+	  var params = {
+		  "Filter.1.Name": "instance-state-name",
+		  "Filter.1.Value.1": "running"
+	  };
+	  ec2.call("DescribeInstances", params, function(err, res) {
+		assert.ok(res.reservationSet);
+		done(err)
+		})
+	  })
+   })
 })


### PR DESCRIPTION
Updated the default AWS API version for EC2 requests because the specified version of AWS API does not support filters. Also, added a test for filters. In addition, I made a minor refactor that makes sure the options always come after the Action in the request body to make debugging easier.
