### PR TITLE
Handle single error responses from AWS.

### DIFF
--- a/lib/aws.js
+++ b/lib/aws.js
@@ -118,10 +118,15 @@ var genericAWSClient = function(obj) {
         res.addListener('end', function() {
           var parser = new xml2js.Parser();
           parser.addListener('end', function(result) {
-            if (typeof result != "undefined" && typeof result.Errors != "undefined"){
-              callback(new Error(result.Errors.Error.Message), result)
+            if (typeof result != "undefined") {
+              var err = result.Error || (result.Errors ? result.Errors.Error : null)
+              if (err) {
+                callback(new Error(err.Message), result)
+              } else {
+                callback(null, result)
+              }
             } else {
-              callback(null, result)
+              callback(new Error('Unable to parse XML from AWS.'))
             }
           });
           parser.parseString(data);


### PR DESCRIPTION
The result object can either have `Error` or `Errors` depending on the service or the number of errors generated.

Refs livelycode/aws-lib/issues#42
