### PR TITLE
Add STS support for cw, ec2, elb, simpledb, and sqs.

### DIFF
--- a/lib/cw.js
+++ b/lib/cw.js
@@ -8,7 +8,8 @@ exports.init = function(genericAWSClient) {
       path: options.path || "/",
       accessKeyId: accessKeyId,
       secretAccessKey: secretAccessKey,
-      secure: options.secure
+      secure: options.secure,
+      token: options.token
     });
     var callFn = function(action, query, callback) {
       query["Action"] = action

--- a/lib/ec2.js
+++ b/lib/ec2.js
@@ -8,7 +8,8 @@ exports.init = function(genericAWSClient) {
       path: options.path || "/",
       accessKeyId: accessKeyId,
       secretAccessKey: secretAccessKey,
-      secure: options.secure
+      secure: options.secure,
+      token: options.token
     });
     var callFn = function(action, opts, callback) {
 	  var query = {};

--- a/lib/elb.js
+++ b/lib/elb.js
@@ -8,7 +8,8 @@ exports.init = function(genericAWSClient) {
       path: options.path || "/",
       accessKeyId: accessKeyId,
       secretAccessKey: secretAccessKey,
-      secure: options.secure
+      secure: options.secure,
+      token: options.token
     });
     var callFn = function(action, query, callback) {
       query["Action"] = action

--- a/lib/simpledb.js
+++ b/lib/simpledb.js
@@ -7,7 +7,8 @@ exports.init = function(genericAWSClient) {
       path: options.path || "/",
       accessKeyId: accessKeyId,
       secretAccessKey: secretAccessKey,
-      secure: options.secure
+      secure: options.secure,
+      token: options.token
     })
     var callFn = function(action, query, callback) {
       query["Action"] = action

--- a/lib/sqs.js
+++ b/lib/sqs.js
@@ -8,7 +8,8 @@ exports.init = function(genericAWSClient) {
       accessKeyId: accessKeyId,
       secretAccessKey: secretAccessKey,
       secure: options.secure,
-      agent: options.agent
+      agent: options.agent,
+      token: options.token
     })
     var callFn = function(action, query, callback) {
       query["Action"] = action


### PR DESCRIPTION
Allows you to specify an STS token as an option so these services can be used with credentials generated by IAM Roles.

See: http://docs.aws.amazon.com/STS/latest/UsingSTS/UsingTokens.html
