### PR TITLE
Fix sqs client variable

### DIFF
--- a/lib/sqs.js
+++ b/lib/sqs.js
@@ -17,7 +17,7 @@ function init(genericAWSClient) {
     });
 
     return {
-      client: aws,
+      client: client,
       call: call
     };
 


### PR DESCRIPTION
When the aws/client variables were refactored in 81e72bec9, the sqs client was broken.  The `aws` client variable was renamed to `client` but `aws` was still being returned.
