### PR TITLE
Update global vars after updating obj

### DIFF
--- a/lib/aws.js
+++ b/lib/aws.js
@@ -65,6 +65,11 @@ function genericAWSClient(obj) {
     
     // Try to set credentials with metadata API if no credentials provided
     metadata.readCredentials(obj, function(err) {
+      // Set global vars as obj has changed
+      secretAccessKey = obj.secretAccessKey;
+      accessKeyId = obj.accessKeyId;
+      securityToken = obj.token;
+        
       if (err) return callback(err);
       var date = new Date();
 


### PR DESCRIPTION
Update the global vars so that secretAccessKey and accessKeyId are updated after metadata.readCredentials.  Currently these variables are not set based on updates made to obj in metadata.js readCredentials function.
