### PR TITLE
fixing aws reference in SQS lib

### DIFF
--- a/lib/sqs.js
+++ b/lib/sqs.js
@@ -17,7 +17,7 @@ function init(genericAWSClient) {
     });
 
     return {
-      client: aws,
+      client: client,
       call: call
     };
 


### PR DESCRIPTION
All the other libraries reference the client object, whereas this one references an undefined aws object.  This is likely leftover from some refactor
