### PR TITLE
retrieve detected security fields from readCredentials

### DIFF
--- a/lib/aws.js
+++ b/lib/aws.js
@@ -64,9 +64,13 @@ function genericAWSClient(obj) {
     })(callback)
     
     // Try to set credentials with metadata API if no credentials provided
-    metadata.readCredentials(obj, function(err) {
+    metadata.readCredentials(obj, function(err, data) {
       if (err) return callback(err);
       var date = new Date();
+
+      securityToken = data.token;
+      accessKeyId = data.accessKeyId;
+      secretAccessKey = data.secretAccessKey;
 
       query = addQueryProperties(query, securityToken, accessKeyId, date);
       var body = qs.stringify(query);


### PR DESCRIPTION
There is something weird going on here, but basically `readRecommendation()` return data in the object passed as the 2nd parameter in the callback, but because it returns a reference to the same object passed as its 1st parameter, then it also updates that. What it doesn't update is the `genericAWSClient()` local variables inited in lines 43~50 - which is what the rest of the code actually use. so instead of ignoring data found by `readRecommendations()` we should use it.

I would have refactored the API of `readRecommendations` to be less confusing (both have an "out parameter" and pass it to the callback? weird) but this change is the minimal to get IAM role based authentication to work.
