### PR TITLE
Fix error with undeclared variable

### DIFF
--- a/lib/sqs.js
+++ b/lib/sqs.js
@@ -17,7 +17,7 @@ function init(genericAWSClient) {
     });
 
     return {
-      client: aws,
+      client: client,
       call: call
     };
 


### PR DESCRIPTION
Looks like a simple missprint for me - aws is undefined variable and the client should be there.
otherwise You do see "ReferenceError: aws is not defined"
